### PR TITLE
UPDATE for PHP7+

### DIFF
--- a/code/lib/bedrock/Spyc.php
+++ b/code/lib/bedrock/Spyc.php
@@ -775,11 +775,10 @@ class Spyc {
       $this->_containsGroupAlias = false;
     }
 
+    if (!is_array ($_arr)) { $_arr = array (); }
 
     // Adding string or numeric key to the innermost level or $this->arr.
     if (is_string($key) && $key == '<<') {
-      if (!is_array ($_arr)) { $_arr = array (); }
-
       $_arr = array_merge ($_arr, $value);
     } else if ($key || $key === '' || $key === '0') {
       $_arr[$key] = $value;


### PR DESCRIPTION
The problem is that our variable $_arr is not set or initialized as an array() and being undefined in the first place! This was apparently fine in PHP 7.0 and below, but not anymore. Now, PHP will NOT assume or automatically fix our problem any longer, and we need to explicitly set it as array() a priory.